### PR TITLE
Claude/fix tts duplicate announcement 011 cv2tazvr y829 jcm g2v q6r

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -465,10 +465,23 @@ async function main() {
             // If a custom-reward-id is present, it means some other reward was redeemed,
             // so we ignore the message for TTS processing.
             if (tags['custom-reward-id']) {
-                logger.debug({ 
-                    channelNameNoHash, 
-                    rewardId: tags['custom-reward-id'] 
+                logger.debug({
+                    channelNameNoHash,
+                    rewardId: tags['custom-reward-id']
                 }, 'Channel Points redemption detected in chat - ignoring (handled by EventSub)');
+                return;
+            }
+
+            // NOTE: Subscription events (sub, resub, gift sub, raid) are now handled exclusively via EventSub
+            // to avoid duplicate TTS announcements. Filter out these system messages from IRC.
+            const msgId = tags['msg-id'];
+            const eventSubManagedMessages = ['sub', 'resub', 'subgift', 'submysterygift', 'giftpaidupgrade', 'rewardgift', 'anongiftpaidupgrade', 'raid'];
+            if (msgId && eventSubManagedMessages.includes(msgId)) {
+                logger.debug({
+                    channelNameNoHash,
+                    msgId,
+                    username
+                }, 'System message detected in chat - ignoring (handled by EventSub)');
                 return;
             }
 

--- a/src/bot.js
+++ b/src/bot.js
@@ -474,8 +474,18 @@ async function main() {
 
             // NOTE: Subscription events (sub, resub, gift sub, raid) are now handled exclusively via EventSub
             // to avoid duplicate TTS announcements. Filter out these system messages from IRC.
+            // IMPORTANT: Only filter events that have EventSub equivalents:
+            // - sub → channel.subscribe
+            // - resub → channel.subscription.message
+            // - subgift → channel.subscription.gift
+            // - anonsubgift → channel.subscription.gift (is_anonymous=true)
+            // - submysterygift → channel.subscription.gift
+            // - raid → channel.raid
+            // Events WITHOUT EventSub equivalents (DO NOT filter):
+            // - giftpaidupgrade, anongiftpaidupgrade (user upgrades gift sub to paid)
+            // - primepaidupgrade (user upgrades Prime sub to paid)
             const msgId = tags['msg-id'];
-            const eventSubManagedMessages = ['sub', 'resub', 'subgift', 'submysterygift', 'giftpaidupgrade', 'rewardgift', 'anongiftpaidupgrade', 'raid'];
+            const eventSubManagedMessages = ['sub', 'resub', 'subgift', 'anonsubgift', 'submysterygift', 'raid'];
             if (msgId && eventSubManagedMessages.includes(msgId)) {
                 logger.debug({
                     channelNameNoHash,

--- a/src/components/twitch/eventsub.js
+++ b/src/components/twitch/eventsub.js
@@ -338,14 +338,19 @@ async function handleEventNotification(subscriptionType, event, channelName) {
             return;
     }
 
-    // Enqueue the event for TTS
+    // Publish to Pub/Sub for distribution to all instances
+    // This ensures shared chat sessions and multi-instance deployments work correctly
     if (ttsText) {
-        logger.debug({ channelName, text: ttsText, user: username }, 'Enqueueing EventSub event for TTS');
-        await ttsQueue.enqueue(channelName, {
+        logger.debug({ channelName, text: ttsText, user: username }, 'Publishing EventSub event to Pub/Sub for TTS');
+
+        // Get shared session info for distribution to all participating channels
+        const sharedSessionInfo = await getSharedSessionInfo(channelName);
+
+        await publishTtsEvent(channelName, {
             text: ttsText,
             user: username,
             type: 'event'
-        });
+        }, sharedSessionInfo);
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Routes EventSub TTS events through Pub/Sub (with shared chat distribution) and filters IRC sub/raid system messages to avoid duplicate TTS.
> 
> - **Event handling**:
>   - **`src/bot.js`**:
>     - Filter IRC system messages with `tags['msg-id']` in `['sub','resub','subgift','anonsubgift','submysterygift','raid']` to avoid duplicate TTS (handled by EventSub).
>     - Continue ignoring Channel Points messages when `tags['custom-reward-id']` is present.
>   - **`src/components/twitch/eventsub.js`**:
>     - Replace direct `ttsQueue.enqueue` with `publishTtsEvent(...)` and include shared session info via `getSharedSessionInfo(...)` for cross-instance/shared chat distribution.
>     - Adjust logging to reflect Pub/Sub publishing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b95fe1f6613c82a5c58ab1637a9901ff5806315. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->