### PR TITLE
Fix variable collision: rename msgId to systemMessageType

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -484,12 +484,12 @@ async function main() {
             // Events WITHOUT EventSub equivalents (DO NOT filter):
             // - giftpaidupgrade, anongiftpaidupgrade (user upgrades gift sub to paid)
             // - primepaidupgrade (user upgrades Prime sub to paid)
-            const msgId = tags['msg-id'];
+            const systemMessageType = tags['msg-id'];
             const eventSubManagedMessages = ['sub', 'resub', 'subgift', 'anonsubgift', 'submysterygift', 'raid'];
-            if (msgId && eventSubManagedMessages.includes(msgId)) {
+            if (systemMessageType && eventSubManagedMessages.includes(systemMessageType)) {
                 logger.debug({
                     channelNameNoHash,
-                    msgId,
+                    msgId: systemMessageType,
                     username
                 }, 'System message detected in chat - ignoring (handled by EventSub)');
                 return;


### PR DESCRIPTION
SyntaxError: Identifier 'msgId' has already been declared

Line 444 declares msgId for IRC deduplication (message ID) Line 487 was redeclaring msgId for system message filtering (msg-id type)

These are different things:
- tags.id = unique message identifier for deduplication
- tags['msg-id'] = message type (sub/resub/raid) for filtering

Renamed second variable to systemMessageType for clarity and to avoid collision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the IRC system message identifier from `msgId` to `systemMessageType` to prevent collision with the IRC message ID used for deduplication.
> 
> - **IRC message handler (src/bot.js)**:
>   - Rename `msgId` (from `tags['msg-id']`) to `systemMessageType` for system message filtering.
>   - Update checks and logging to use `systemMessageType` instead of `msgId`, avoiding collision with the dedupe `msgId` (`tags.id`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38dfa9de6bee5fcc27d22ed57f1d894892586246. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->