### PR TITLE
Claude/chatvibes bot free design 01 bdm yj g crf v qkw3 f31449i j

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,4 +88,4 @@ TTS configuration is stored in Firestore's `ttsChannelConfigs` collection with t
 - User-specific preferences (including language)
 
 ### Migration
-Run `node scripts/migrateBotMode.js` to add the `botMode` field to existing channel configs (defaults to `'anonymous'`).
+Run `node scripts/migrateBotMode.js` to add the `botMode` field to existing channel configs (sets to `'authenticated'` to preserve current bot behavior for existing users).

--- a/scripts/migrateBotMode.js
+++ b/scripts/migrateBotMode.js
@@ -1,6 +1,7 @@
 // migrateBotMode.js
 // Script to add botMode field to existing ttsChannelConfigs documents
-// Default: 'anonymous' (bot-free mode)
+// For existing channels: Sets to 'authenticated' (preserves current bot behavior)
+// New channels will use 'anonymous' as the default from ttsConstants.js
 
 import { initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
@@ -11,7 +12,8 @@ initializeApp();
 const db = getFirestore();
 
 async function migrateBotMode() {
-  console.log('Starting migration to add botMode field to channel configs...');
+  console.log('Starting migration to add botMode field to existing channel configs...');
+  console.log('Note: Existing channels will be set to "authenticated" to preserve current behavior.\n');
 
   const ttsConfigsRef = db.collection('ttsChannelConfigs');
   let migratedCount = 0;
@@ -33,15 +35,15 @@ async function migrateBotMode() {
       const channelData = doc.data();
 
       if (!channelData.botMode) {
-        // Channel doesn't have botMode field yet
-        console.log(`Channel [${channelName}] missing botMode field. Will add default 'anonymous'.`);
+        // Channel doesn't have botMode field yet - these are existing users who have been using the bot
+        console.log(`Channel [${channelName}] missing botMode field. Will add 'authenticated' to preserve existing behavior.`);
 
         tasks.push((async () => {
           await ttsConfigsRef.doc(channelName).set({
-            botMode: 'anonymous', // Default to bot-free mode
+            botMode: 'authenticated', // Preserve existing authenticated bot behavior
             updatedAt: new Date(),
           }, { merge: true });
-          console.log(`  ✅ Added botMode='anonymous' for [${channelName}].`);
+          console.log(`  ✅ Added botMode='authenticated' for [${channelName}].`);
           migratedCount += 1;
         })());
       } else {
@@ -56,9 +58,12 @@ async function migrateBotMode() {
     console.log(`Checked ${checkedCount} channels in 'ttsChannelConfigs'.`);
     console.log(`Added botMode field to ${migratedCount} channels.`);
     console.log(`Skipped ${skippedCount} channels (already had botMode).`);
-    console.log('Migration complete!');
-    console.log('\nNote: Default mode is "anonymous" (bot-free, read-only IRC).');
-    console.log('To enable chat commands for a channel, set botMode="authenticated" in Firestore.');
+    console.log('\nMigration complete!');
+    console.log('\n📝 What changed:');
+    console.log('   - Existing channels: Set to "authenticated" (keeps bot with chat commands)');
+    console.log('   - New channels: Will default to "anonymous" (bot-free mode)');
+    console.log('\n💡 To switch a channel to bot-free mode:');
+    console.log('   Set botMode="anonymous" in Firestore for that channel');
   } catch (error) {
     console.error('An error occurred during migration:', error);
   }

--- a/src/components/commands/commandProcessor.js
+++ b/src/components/commands/commandProcessor.js
@@ -4,6 +4,7 @@ import logger from '../../lib/logger.js';
 import commandHandlers from './handlers/index.js';
 // We might need access to the IRC client to send command responses
 import { getIrcClient, isAnonymousMode } from '../twitch/ircClient.js';
+import { getTtsState } from '../tts/ttsState.js';
 
 
 const COMMAND_PREFIX = '!'; // Define the prefix for commands
@@ -127,9 +128,28 @@ async function processMessage(channelNameNoHash, tags, message) {
         return null; // Return null if user lacks permission for base command
     }
 
-    // --- Execute Command ---
-    const anonymousMode = isAnonymousMode();
-    logger.info(`Executing command !${commandName} for user ${tags.username} in #${channelNameNoHash} (anonymous mode: ${anonymousMode})`);
+    // --- Check channel-specific bot mode ---
+    // Even if IRC is in authenticated mode globally, individual channels can be in bot-free mode
+    let channelBotMode = 'anonymous'; // Default to bot-free
+    try {
+        const ttsState = await getTtsState(channelNameNoHash);
+        channelBotMode = ttsState.botMode || 'anonymous';
+    } catch (error) {
+        logger.error({ err: error, channel: channelNameNoHash }, 'Error fetching channel botMode, defaulting to anonymous');
+    }
+
+    const isChannelAnonymous = channelBotMode === 'anonymous';
+    const globalAnonymousMode = isAnonymousMode();
+    const anonymousMode = isChannelAnonymous || globalAnonymousMode;
+
+    logger.info(`Executing command !${commandName} for user ${tags.username} in #${channelNameNoHash} (channel botMode: ${channelBotMode}, global anonymous: ${globalAnonymousMode}, effective anonymous: ${anonymousMode})`);
+    
+    // Block command execution if channel is in bot-free mode
+    if (isChannelAnonymous) {
+        logger.info(`Command !${commandName} blocked: channel ${channelNameNoHash} is in bot-free mode (anonymous)`);
+        return null; // Don't execute command in bot-free mode
+    }
+
     try {
         const context = {
             channel: `#${channelNameNoHash}`,

--- a/src/components/commands/commandProcessor.js
+++ b/src/components/commands/commandProcessor.js
@@ -128,9 +128,9 @@ async function processMessage(channelNameNoHash, tags, message) {
         return null; // Return null if user lacks permission for base command
     }
 
-    // --- Check channel-specific bot mode ---
-    // Even if IRC is in authenticated mode globally, individual channels can be in bot-free mode
-    let channelBotMode = 'anonymous'; // Default to bot-free
+    // --- Check Bot Mode (Channel-level and Global) ---
+    // Determine effective anonymous mode by combining channel-level and global IRC connection mode
+    let channelBotMode = 'anonymous'; // Default assumption
     try {
         const ttsState = await getTtsState(channelNameNoHash);
         channelBotMode = ttsState.botMode || 'anonymous';
@@ -140,16 +140,19 @@ async function processMessage(channelNameNoHash, tags, message) {
 
     const isChannelAnonymous = channelBotMode === 'anonymous';
     const globalAnonymousMode = isAnonymousMode();
-    const anonymousMode = isChannelAnonymous || globalAnonymousMode;
 
-    logger.info(`Executing command !${commandName} for user ${tags.username} in #${channelNameNoHash} (channel botMode: ${channelBotMode}, global anonymous: ${globalAnonymousMode}, effective anonymous: ${anonymousMode})`);
-    
-    // Block command execution if channel is in bot-free mode
-    if (isChannelAnonymous) {
-        logger.info(`Command !${commandName} blocked: channel ${channelNameNoHash} is in bot-free mode (anonymous)`);
-        return null; // Don't execute command in bot-free mode
+    // Effective anonymous mode: true if EITHER channel wants bot-free OR global IRC is anonymous
+    const effectiveAnonymousMode = isChannelAnonymous || globalAnonymousMode;
+
+    logger.info(`Command !${commandName} for user ${tags.username} in #${channelNameNoHash} - Channel botMode: ${channelBotMode}, Global anonymous: ${globalAnonymousMode}, Effective anonymous: ${effectiveAnonymousMode}`);
+
+    // Block command execution if in effective anonymous mode (no chat responses possible)
+    if (effectiveAnonymousMode) {
+        logger.info(`Command !${commandName} blocked: channel ${channelNameNoHash} is in effective bot-free mode (channel: ${isChannelAnonymous}, global: ${globalAnonymousMode})`);
+        return null; // Don't execute command when bot cannot respond
     }
 
+    // --- Execute Command ---
     try {
         const context = {
             channel: `#${channelNameNoHash}`,
@@ -159,7 +162,7 @@ async function processMessage(channelNameNoHash, tags, message) {
             command: commandName, // Pass the executed command name for context within subcommand handlers
             replyToId: tags?.id || tags?.['message-id'] || null, // Add reply ID from message tags
             ircClient: getIrcClient(),
-            canReply: !anonymousMode, // In anonymous mode, bot cannot send chat messages
+            canReply: !effectiveAnonymousMode, // Consistent with blocking logic
             logger: logger
         };
         await handler.execute(context);
@@ -169,8 +172,8 @@ async function processMessage(channelNameNoHash, tags, message) {
         logger.error({ err: error, command: commandName, user: tags.username, channel: channelNameNoHash },
             `Error executing command !${commandName}`);
 
-        // Only send error message to chat if not in anonymous mode
-        if (!anonymousMode) {
+        // Only send error message to chat if not in effective anonymous mode
+        if (!effectiveAnonymousMode) {
             try {
                 const ircClient = getIrcClient();
                 await ircClient.say(`#${channelNameNoHash}`, `Oops! Something went wrong trying to run !${commandName}.`);
@@ -178,7 +181,7 @@ async function processMessage(channelNameNoHash, tags, message) {
                 logger.error({ err: sayError }, 'Failed to send command execution error message to chat.');
             }
         } else {
-            logger.warn(`Cannot send error message to chat: bot is in anonymous mode (read-only).`);
+            logger.warn(`Cannot send error message to chat: bot is in effective anonymous mode (read-only).`);
         }
         return commandName; // Command was attempted, return command name
     }

--- a/tests/unit/commandProcessor.test.js
+++ b/tests/unit/commandProcessor.test.js
@@ -531,4 +531,181 @@ describe('commandProcessor module', () => {
       );
     });
   });
+
+  describe('bot-free mode blocking', () => {
+    test('should block command execution when channel is in bot-free mode (anonymous)', async () => {
+      const mockHandler = {
+        execute: jest.fn().mockResolvedValue(undefined),
+        permission: 'everyone'
+      };
+
+      jest.resetModules();
+
+      jest.unstable_mockModule('../../src/lib/logger.js', () => ({
+        default: mockLogger
+      }));
+
+      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
+        getIrcClient: jest.fn(() => mockIrcClient),
+        isAnonymousMode: jest.fn(() => false) // Global IRC is authenticated
+      }));
+
+      jest.unstable_mockModule('../../src/components/tts/ttsState.js', () => ({
+        getTtsState: jest.fn(() => Promise.resolve({
+          botMode: 'anonymous' // Channel is in bot-free mode
+        }))
+      }));
+
+      jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
+        default: {
+          'tts': mockHandler
+        }
+      }));
+
+      commandProcessor = await import('../../src/components/commands/commandProcessor.js');
+
+      const result = await commandProcessor.processMessage(
+        'testchannel',
+        { username: 'user', id: 'msg123' },
+        '!tts test'
+      );
+
+      expect(mockHandler.execute).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Command !tts blocked: channel testchannel is in bot-free mode')
+      );
+    });
+
+    test('should allow command execution when channel is in authenticated mode', async () => {
+      const mockHandler = {
+        execute: jest.fn().mockResolvedValue(undefined),
+        permission: 'everyone'
+      };
+
+      jest.resetModules();
+
+      jest.unstable_mockModule('../../src/lib/logger.js', () => ({
+        default: mockLogger
+      }));
+
+      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
+        getIrcClient: jest.fn(() => mockIrcClient),
+        isAnonymousMode: jest.fn(() => false) // Global IRC is authenticated
+      }));
+
+      jest.unstable_mockModule('../../src/components/tts/ttsState.js', () => ({
+        getTtsState: jest.fn(() => Promise.resolve({
+          botMode: 'authenticated' // Channel allows bot commands
+        }))
+      }));
+
+      jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
+        default: {
+          'tts': mockHandler
+        }
+      }));
+
+      commandProcessor = await import('../../src/components/commands/commandProcessor.js');
+
+      const result = await commandProcessor.processMessage(
+        'testchannel',
+        { username: 'user', id: 'msg123' },
+        '!tts test'
+      );
+
+      expect(mockHandler.execute).toHaveBeenCalled();
+      expect(result).toBe('tts');
+    });
+
+    test('should default to anonymous mode if getTtsState fails', async () => {
+      const mockHandler = {
+        execute: jest.fn().mockResolvedValue(undefined),
+        permission: 'everyone'
+      };
+
+      jest.resetModules();
+
+      jest.unstable_mockModule('../../src/lib/logger.js', () => ({
+        default: mockLogger
+      }));
+
+      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
+        getIrcClient: jest.fn(() => mockIrcClient),
+        isAnonymousMode: jest.fn(() => false)
+      }));
+
+      jest.unstable_mockModule('../../src/components/tts/ttsState.js', () => ({
+        getTtsState: jest.fn(() => Promise.reject(new Error('Firestore error')))
+      }));
+
+      jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
+        default: {
+          'tts': mockHandler
+        }
+      }));
+
+      commandProcessor = await import('../../src/components/commands/commandProcessor.js');
+
+      const result = await commandProcessor.processMessage(
+        'testchannel',
+        { username: 'user', id: 'msg123' },
+        '!tts test'
+      );
+
+      // Should block because it defaults to anonymous mode on error
+      expect(mockHandler.execute).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          err: expect.any(Error),
+          channel: 'testchannel'
+        }),
+        expect.stringContaining('Error fetching channel botMode')
+      );
+    });
+
+    test('should block when global IRC is anonymous even if channel botMode is authenticated', async () => {
+      const mockHandler = {
+        execute: jest.fn().mockResolvedValue(undefined),
+        permission: 'everyone'
+      };
+
+      jest.resetModules();
+
+      jest.unstable_mockModule('../../src/lib/logger.js', () => ({
+        default: mockLogger
+      }));
+
+      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
+        getIrcClient: jest.fn(() => mockIrcClient),
+        isAnonymousMode: jest.fn(() => true) // Global IRC is anonymous
+      }));
+
+      jest.unstable_mockModule('../../src/components/tts/ttsState.js', () => ({
+        getTtsState: jest.fn(() => Promise.resolve({
+          botMode: 'authenticated' // This shouldn't matter when global is anonymous
+        }))
+      }));
+
+      jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
+        default: {
+          'tts': mockHandler
+        }
+      }));
+
+      commandProcessor = await import('../../src/components/commands/commandProcessor.js');
+
+      const result = await commandProcessor.processMessage(
+        'testchannel',
+        { username: 'user', id: 'msg123' },
+        '!tts test'
+      );
+
+      // Should still execute since we only block on channel-level anonymous mode
+      // The global anonymous mode is for when NO channels have auth
+      expect(mockHandler.execute).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enforces channel/global bot-free mode by blocking command execution, updates migration to set existing channels to authenticated, and adds targeted unit tests.
> 
> - **Commands**:
>   - Compute effective anonymous mode from channel `botMode` (via `getTtsState`) and global IRC state; block command execution when anonymous.
>   - Pass `canReply` based on effective mode; adjust error messaging and logging accordingly.
> - **Tests**:
>   - Add unit tests covering bot-free blocking, authenticated allowance, error fallback to anonymous, and global anonymous behavior.
> - **Scripts/Docs**:
>   - Update `scripts/migrateBotMode.js` to set existing channels to `botMode: 'authenticated'` with clearer logs and summary.
>   - Update `CLAUDE.md` migration note to reflect the new default for existing channels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16831b22be054ac594ff130bc43fcff6b7574a9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->