### PR TITLE
Upgrade TTS message filtering logs from debug to info level

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -65,14 +65,14 @@ function isDuplicatePubSubEvent(channelName, eventData) {
         }
 
         if (lastTs && now - lastTs < PUBSUB_DEDUP_TTL_MS) {
-            logger.debug({
+            logger.info({
                 channel: channelName,
                 user,
                 textPreview: text?.substring(0, 30),
                 messageId,
                 key,
                 ageMs: now - lastTs
-            }, 'Pub/Sub dedupe: Blocked by local cache');
+            }, 'TTS message blocked: Duplicate detected in local cache (dedupe)');
             return true;
         }
 
@@ -110,14 +110,14 @@ async function claimTtsEventGlobal(channelName, eventData, ttlMs = PUBSUB_DEDUP_
                 const data = snap.data() || {};
                 const expireAtMs = typeof data.expireAtMs === 'number' ? data.expireAtMs : 0;
                 if (expireAtMs > now) {
-                    logger.debug({
+                    logger.info({
                         channel: channelName,
                         user,
                         textPreview: text?.substring(0, 30),
                         messageId,
                         keyRaw,
                         ageMs: now - data.createdAtMs
-                    }, 'Pub/Sub dedupe: Blocked by global claim (Firestore)');
+                    }, 'TTS message blocked: Duplicate detected in global claim (Firestore dedupe)');
                     return false; // already claimed recently
                 }
             }
@@ -368,13 +368,13 @@ async function main() {
 
             // Pub/Sub dedupe: local memory check
             if (isDuplicatePubSubEvent(channelName, eventData)) {
-                logger.debug({ channel: channelName, user: eventData.user, textPreview: eventData.text?.substring(0, 30) }, 'Pub/Sub dedupe: Skipping duplicate TTS enqueue (local cache)');
+                logger.info({ channel: channelName, user: eventData.user, textPreview: eventData.text?.substring(0, 30) }, 'Skipping duplicate TTS enqueue (blocked by local cache)');
                 return;
             }
             // Pub/Sub dedupe: cross-instance Firestore claim (authoritative)
             const claimed = await claimTtsEventGlobal(channelName, eventData);
             if (!claimed) {
-                logger.debug({ channel: channelName, user: eventData.user, textPreview: eventData.text?.substring(0, 30) }, 'Pub/Sub dedupe: Skipping duplicate TTS enqueue (global claim)');
+                logger.info({ channel: channelName, user: eventData.user, textPreview: eventData.text?.substring(0, 30) }, 'Skipping duplicate TTS enqueue (blocked by global Firestore claim)');
                 return;
             }
             await ttsQueue.enqueue(channelName, eventData, sharedSessionInfo);

--- a/src/components/twitch/eventsub.js
+++ b/src/components/twitch/eventsub.js
@@ -402,7 +402,7 @@ async function handleEventNotification(subscriptionType, event, channelName) {
                     logger.debug({ channel: channelName, user: username, command: processedCommandName }, 'Published command text for TTS');
                 } else if (ttsConfig.mode === 'bits_points_only') {
                     // In bits/points only mode, do not read commands
-                    logger.debug({ channel: channelName, mode: ttsConfig.mode }, 'Skipping command in bits_points_only mode');
+                    logger.info({ channel: channelName, mode: ttsConfig.mode }, 'Skipping command in bits_points_only mode');
                     return;
                 } else {
                     // Command mode or tts command - command handler already enqueued if needed


### PR DESCRIPTION
Previously, TTS messages were being filtered by deduplication logic but the logs were at debug level, making them invisible in Cloud Logs. This caused confusion when messages were silently skipped (e.g., test 2, 4, 5 in the reported example).

Changes:
- Upgraded local cache dedup logs from debug to info
- Upgraded Firestore global claim dedup logs from debug to info
- Upgraded Pub/Sub handler dedup logs from debug to info
- Made log messages clearer: "TTS message blocked: Duplicate detected..."
- Also upgraded bits_points_only mode skip log to info level

Now when messages are filtered by the deduplication system, the reason will be visible in production Cloud Logs, making troubleshooting much easier.