### PR TITLE
Add comprehensive messageId logging to diagnose aggressive dedup

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -50,6 +50,7 @@ function isDuplicatePubSubEvent(channelName, eventData) {
         const messageId = eventData?.messageId || '';
 
         // Use messageId if available (from EventSub), otherwise fall back to text-based dedup
+        const usingMessageId = !!messageId;
         const key = messageId
             ? `${channelName}|${messageId}`
             : `${channelName}|${user}|${text}`;
@@ -65,14 +66,16 @@ function isDuplicatePubSubEvent(channelName, eventData) {
         }
 
         if (lastTs && now - lastTs < PUBSUB_DEDUP_TTL_MS) {
+            const dedupMethod = usingMessageId ? 'messageId' : 'text-based';
             logger.info({
                 channel: channelName,
                 user,
                 textPreview: text?.substring(0, 30),
-                messageId,
-                key,
+                messageId: messageId || 'N/A',
+                dedupMethod,
+                keyPreview: key.substring(0, 80),
                 ageMs: now - lastTs
-            }, 'TTS message blocked: Duplicate detected in local cache (dedupe)');
+            }, `TTS message blocked: Duplicate detected in local cache (${dedupMethod} dedupe)`);
             return true;
         }
 
@@ -96,6 +99,7 @@ async function claimTtsEventGlobal(channelName, eventData, ttlMs = PUBSUB_DEDUP_
     if (!channelName || (!messageId && !text)) return true; // if missing data, do not block
 
     // Use messageId if available (from EventSub), otherwise fall back to text-based dedup
+    const usingMessageId = !!messageId;
     const keyRaw = messageId
         ? `${channelName}|${messageId}`
         : `${channelName}|${user}|${text}`;
@@ -110,14 +114,16 @@ async function claimTtsEventGlobal(channelName, eventData, ttlMs = PUBSUB_DEDUP_
                 const data = snap.data() || {};
                 const expireAtMs = typeof data.expireAtMs === 'number' ? data.expireAtMs : 0;
                 if (expireAtMs > now) {
+                    const dedupMethod = usingMessageId ? 'messageId' : 'text-based';
                     logger.info({
                         channel: channelName,
                         user,
                         textPreview: text?.substring(0, 30),
-                        messageId,
-                        keyRaw,
+                        messageId: messageId || 'N/A',
+                        dedupMethod,
+                        keyRawPreview: keyRaw.substring(0, 80),
                         ageMs: now - data.createdAtMs
-                    }, 'TTS message blocked: Duplicate detected in global claim (Firestore dedupe)');
+                    }, `TTS message blocked: Duplicate detected in global claim (${dedupMethod} Firestore dedupe)`);
                     return false; // already claimed recently
                 }
             }

--- a/src/lib/pubsub.js
+++ b/src/lib/pubsub.js
@@ -68,18 +68,19 @@ export async function publishTtsEvent(channelName, eventData, sharedSessionInfo 
         const messageId = await topic.publishMessage({ data: dataBuffer });
         
         const logData = {
-            messageId,
+            pubsubMessageId: messageId,
             channel: channelName,
             user: eventData.user,
+            eventMessageId: eventData.messageId || 'N/A',
             textPreview: eventData.text?.substring(0, 30)
         };
 
         if (sharedSessionInfo) {
             logData.sessionId = sharedSessionInfo.sessionId;
             logData.sharedChannels = sharedSessionInfo.channels;
-            logger.debug(logData, `[SharedChat:${sharedSessionInfo.sessionId}] Published TTS event to Pub/Sub for shared session`);
+            logger.debug(logData, `[SharedChat:${sharedSessionInfo.sessionId}] Published TTS event to Pub/Sub (EventSub msgId: ${eventData.messageId || 'N/A'})`);
         } else {
-            logger.debug(logData, `Published TTS event to Pub/Sub`);
+            logger.debug(logData, `Published TTS event to Pub/Sub (EventSub msgId: ${eventData.messageId || 'N/A'})`);
         }
 
         return messageId;
@@ -135,8 +136,9 @@ export async function subscribeTtsEvents(handler) {
                 const { channelName, eventData, sharedSessionInfo, source } = data;
 
                 const logData = {
-                    messageId: message.id,
+                    pubsubMessageId: message.id,
                     channel: channelName,
+                    eventMessageId: eventData?.messageId || 'N/A',
                     source,
                     currentRevision: process.env.K_REVISION || 'local'
                 };
@@ -144,9 +146,9 @@ export async function subscribeTtsEvents(handler) {
                 if (sharedSessionInfo) {
                     logData.sessionId = sharedSessionInfo.sessionId;
                     logData.sharedChannels = sharedSessionInfo.channels;
-                    logger.debug(logData, `[SharedChat:${sharedSessionInfo.sessionId}] Received TTS event from Pub/Sub for shared session`);
+                    logger.debug(logData, `[SharedChat:${sharedSessionInfo.sessionId}] Received TTS event from Pub/Sub (EventSub msgId: ${eventData?.messageId || 'N/A'})`);
                 } else {
-                    logger.debug(logData, 'Received TTS event from Pub/Sub');
+                    logger.debug(logData, `Received TTS event from Pub/Sub (EventSub msgId: ${eventData?.messageId || 'N/A'})`);
                 }
 
                 // Call the handler with shared session info


### PR DESCRIPTION
The deduplication system is blocking messages too aggressively. Added detailed logging throughout the entire message flow to diagnose whether EventSub messageIds are being used correctly for deduplication.

Changes:
- Publish step: Log EventSub messageId being sent to Pub/Sub
- Receive step: Log EventSub messageId received from Pub/Sub
- Local cache dedup: Show dedupMethod (messageId vs text-based) and key
- Firestore dedup: Show dedupMethod (messageId vs text-based) and key
- All logs now explicitly show "N/A" if messageId is missing

This will help identify:
1. Whether EventSub is providing unique messageIds
2. Whether messageIds are preserved through Pub/Sub serialization
3. Whether dedup is incorrectly using text-based keys instead of messageIds
4. What the actual dedup keys look like for troubleshooting

Each EventSub chat message should have a unique message_id (UUID format) per Twitch API docs, so messageId-based dedup should never block different messages from the same user.