### PR TITLE
Upgrade TTS message filtering logs from debug to info level

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -67,15 +67,16 @@ function isDuplicatePubSubEvent(channelName, eventData) {
 
         if (lastTs && now - lastTs < PUBSUB_DEDUP_TTL_MS) {
             const dedupMethod = usingMessageId ? 'messageId' : 'text-based';
+            const keyDisplay = key.substring(0, 80);
             logger.info({
                 channel: channelName,
                 user,
                 textPreview: text?.substring(0, 30),
                 messageId: messageId || 'N/A',
                 dedupMethod,
-                keyPreview: key.substring(0, 80),
+                keyPreview: keyDisplay,
                 ageMs: now - lastTs
-            }, `TTS message blocked: Duplicate detected in local cache (${dedupMethod} dedupe)`);
+            }, `TTS message blocked: Duplicate in local cache (${dedupMethod}) - msgId: ${messageId || 'NONE'} - key: ${keyDisplay}`);
             return true;
         }
 
@@ -115,15 +116,16 @@ async function claimTtsEventGlobal(channelName, eventData, ttlMs = PUBSUB_DEDUP_
                 const expireAtMs = typeof data.expireAtMs === 'number' ? data.expireAtMs : 0;
                 if (expireAtMs > now) {
                     const dedupMethod = usingMessageId ? 'messageId' : 'text-based';
+                    const keyDisplay = keyRaw.substring(0, 80);
                     logger.info({
                         channel: channelName,
                         user,
                         textPreview: text?.substring(0, 30),
                         messageId: messageId || 'N/A',
                         dedupMethod,
-                        keyRawPreview: keyRaw.substring(0, 80),
+                        keyRawPreview: keyDisplay,
                         ageMs: now - data.createdAtMs
-                    }, `TTS message blocked: Duplicate detected in global claim (${dedupMethod} Firestore dedupe)`);
+                    }, `TTS message blocked: Duplicate in Firestore (${dedupMethod}) - msgId: ${messageId || 'NONE'} - key: ${keyDisplay}`);
                     return false; // already claimed recently
                 }
             }

--- a/src/lib/pubsub.js
+++ b/src/lib/pubsub.js
@@ -78,9 +78,9 @@ export async function publishTtsEvent(channelName, eventData, sharedSessionInfo 
         if (sharedSessionInfo) {
             logData.sessionId = sharedSessionInfo.sessionId;
             logData.sharedChannels = sharedSessionInfo.channels;
-            logger.debug(logData, `[SharedChat:${sharedSessionInfo.sessionId}] Published TTS event to Pub/Sub (EventSub msgId: ${eventData.messageId || 'N/A'})`);
+            logger.info(logData, `[SharedChat:${sharedSessionInfo.sessionId}] Published to Pub/Sub - EventSub msgId: ${eventData.messageId || 'NONE'}`);
         } else {
-            logger.debug(logData, `Published TTS event to Pub/Sub (EventSub msgId: ${eventData.messageId || 'N/A'})`);
+            logger.info(logData, `Published to Pub/Sub - EventSub msgId: ${eventData.messageId || 'NONE'} - user: ${eventData.user}`);
         }
 
         return messageId;
@@ -146,9 +146,9 @@ export async function subscribeTtsEvents(handler) {
                 if (sharedSessionInfo) {
                     logData.sessionId = sharedSessionInfo.sessionId;
                     logData.sharedChannels = sharedSessionInfo.channels;
-                    logger.debug(logData, `[SharedChat:${sharedSessionInfo.sessionId}] Received TTS event from Pub/Sub (EventSub msgId: ${eventData?.messageId || 'N/A'})`);
+                    logger.info(logData, `[SharedChat:${sharedSessionInfo.sessionId}] Received from Pub/Sub - EventSub msgId: ${eventData?.messageId || 'NONE'}`);
                 } else {
-                    logger.debug(logData, `Received TTS event from Pub/Sub (EventSub msgId: ${eventData?.messageId || 'N/A'})`);
+                    logger.info(logData, `Received from Pub/Sub - EventSub msgId: ${eventData?.messageId || 'NONE'} - user: ${eventData?.user}`);
                 }
 
                 // Call the handler with shared session info


### PR DESCRIPTION
Make messageId and dedup keys visible in log message text to diagnose why some messages are using messageId-based dedup and others are using text-based dedup, causing aggressive filtering.

Changes:
- Pub/Sub publish: Upgraded to info, show EventSub msgId in message text
- Pub/Sub receive: Upgraded to info, show EventSub msgId in message text
- Local cache dedup: Show "msgId: [value or NONE]" and "key: [value]" in message
- Firestore dedup: Show "msgId: [value or NONE]" and "key: [value]" in message

This will reveal:
1. Whether EventSub is providing messageIds for all chat messages
2. Whether Pub/Sub serialization preserves messageIds correctly
3. The actual dedup keys being used (messageId vs text-based)
4. Why some messages show "messageId dedupe" and others show just "dedupe"

Previous logs showed both methods being used simultaneously, suggesting either messageIds are missing from some messages or there's a race condition where messageIds are being lost.