### PR TITLE
fix: Update test suite for IRC to EventSub migration

### DIFF
--- a/tests/unit/chatClient.test.js
+++ b/tests/unit/chatClient.test.js
@@ -32,14 +32,29 @@ jest.unstable_mockModule('../../src/lib/logger.js', () => ({
 jest.unstable_mockModule('../../src/config/index.js', () => ({
     default: {
         twitch: {
-            username: 'botuser'
+            username: 'botuser',
+            accessToken: 'oauth:test-token'
         }
+    }
+}));
+
+// Mock auth
+jest.unstable_mockModule('../../src/components/twitch/auth.js', () => ({
+    getClientId: jest.fn(() => Promise.resolve('test-client-id'))
+}));
+
+// Mock axios directly for API calls
+jest.unstable_mockModule('axios', () => ({
+    default: {
+        post: jest.fn(),
+        get: jest.fn()
     }
 }));
 
 // Import the module under test
 const { sendMessage, getBotUserId, _resetCache } = await import('../../src/components/twitch/chatClient.js');
 const { getUsersByLogin } = await import('../../src/components/twitch/helixClient.js');
+const axios = await import('axios');
 
 describe('chatClient.js', () => {
     beforeEach(() => {
@@ -78,48 +93,71 @@ describe('chatClient.js', () => {
 
     describe('sendMessage', () => {
         it('should send a message successfully', async () => {
-            // Mock broadcaster ID lookup (it calls getUsersByLogin again for the channel)
-            // FIRST call is for channel (broadcaster)
-            getUsersByLogin.mockResolvedValueOnce([{ id: 'broadcaster-id-2', login: 'targetchannel' }])
-                // SECOND call is for bot ID (inside getBotUserId)
-                .mockResolvedValueOnce([{ id: 'bot-id-1', login: 'botuser' }]);
+            // Mock broadcaster ID lookup (it calls getUsersByLogin for the channel)
+            getUsersByLogin.mockResolvedValueOnce([{ id: 'broadcaster-id-2', login: 'targetchannel' }]);
 
-            mockAxios.post.mockResolvedValue({ status: 200 });
+            // Mock bot ID lookup (inside getBotUserId)
+            getUsersByLogin.mockResolvedValueOnce([{ id: 'bot-id-1', login: 'botuser' }]);
+
+            // Mock successful API response
+            axios.default.post.mockResolvedValue({
+                status: 200,
+                data: {
+                    data: [{
+                        is_sent: true
+                    }]
+                }
+            });
 
             const success = await sendMessage('targetchannel', 'Hello World');
 
             expect(success).toBe(true);
-            expect(mockAxios.post).toHaveBeenCalledWith('/chat/messages', {
-                broadcaster_id: 'broadcaster-id-2',
-                sender_id: 'bot-id-1',
-                message: 'Hello World'
-            });
+            expect(axios.default.post).toHaveBeenCalledWith(
+                'https://api.twitch.tv/helix/chat/messages',
+                {
+                    broadcaster_id: 'broadcaster-id-2',
+                    sender_id: 'bot-id-1',
+                    message: 'Hello World'
+                },
+                {
+                    headers: {
+                        'Authorization': 'Bearer test-token',
+                        'Client-Id': 'test-client-id',
+                        'Content-Type': 'application/json'
+                    }
+                }
+            );
         });
 
         it('should fail if bot ID cannot be retrieved', async () => {
-            getUsersByLogin.mockResolvedValue([]); // No bot user found
+            // First call for broadcaster succeeds
+            getUsersByLogin.mockResolvedValueOnce([{ id: 'broadcaster-id-2', login: 'targetchannel' }]);
+            // Second call for bot fails
+            getUsersByLogin.mockResolvedValueOnce([]);
 
             const success = await sendMessage('targetchannel', 'Hello');
 
             expect(success).toBe(false);
-            expect(mockAxios.post).not.toHaveBeenCalled();
+            expect(axios.default.post).not.toHaveBeenCalled();
         });
 
         it('should fail if broadcaster ID cannot be retrieved', async () => {
-            getUsersByLogin.mockResolvedValueOnce([{ id: 'bot-id-1', login: 'botuser' }])
-                .mockResolvedValueOnce([]); // No broadcaster found
+            // First call for broadcaster fails
+            getUsersByLogin.mockResolvedValueOnce([]);
 
             const success = await sendMessage('targetchannel', 'Hello');
 
             expect(success).toBe(false);
-            expect(mockAxios.post).not.toHaveBeenCalled();
+            expect(axios.default.post).not.toHaveBeenCalled();
         });
 
         it('should handle API errors gracefully', async () => {
-            getUsersByLogin.mockResolvedValueOnce([{ id: 'bot-id-1', login: 'botuser' }])
-                .mockResolvedValueOnce([{ id: 'broadcaster-id-2', login: 'targetchannel' }]);
+            // Mock broadcaster ID lookup
+            getUsersByLogin.mockResolvedValueOnce([{ id: 'broadcaster-id-2', login: 'targetchannel' }]);
+            // Mock bot ID lookup
+            getUsersByLogin.mockResolvedValueOnce([{ id: 'bot-id-1', login: 'botuser' }]);
 
-            mockAxios.post.mockRejectedValue(new Error('API Error'));
+            axios.default.post.mockRejectedValue(new Error('API Error'));
 
             const success = await sendMessage('targetchannel', 'Hello');
 

--- a/tests/unit/chatSender.test.js
+++ b/tests/unit/chatSender.test.js
@@ -23,6 +23,12 @@ const mockTimeUtils = {
 };
 jest.unstable_mockModule('../../src/lib/timeUtils.js', () => mockTimeUtils);
 
+// Mock ttsState
+const mockTtsState = {
+    getTtsState: jest.fn(),
+};
+jest.unstable_mockModule('../../src/components/tts/ttsState.js', () => mockTtsState);
+
 // Import module under test
 const { enqueueMessage, clearMessageQueue, initializeChatSender } = await import('../../src/lib/chatSender.js');
 
@@ -30,6 +36,8 @@ describe('chatSender.js', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         clearMessageQueue();
+        // Default to allowing bot responses
+        mockTtsState.getTtsState.mockResolvedValue({ botRespondsInChat: true });
     });
 
     it('should queue and send a message', async () => {
@@ -40,7 +48,7 @@ describe('chatSender.js', () => {
         // Since processing is async and we mocked sleep, we might need to wait a tick
         await new Promise(resolve => setTimeout(resolve, 10));
 
-        expect(mockChatClient.sendMessage).toHaveBeenCalledWith('#testchannel', 'Hello World');
+        expect(mockChatClient.sendMessage).toHaveBeenCalledWith('#testchannel', 'Hello World', { replyToId: null });
     });
 
     it('should truncate long messages', async () => {
@@ -51,7 +59,7 @@ describe('chatSender.js', () => {
         await new Promise(resolve => setTimeout(resolve, 10));
 
         const expectedMessage = 'a'.repeat(497) + '...';
-        expect(mockChatClient.sendMessage).toHaveBeenCalledWith('#testchannel', expectedMessage);
+        expect(mockChatClient.sendMessage).toHaveBeenCalledWith('#testchannel', expectedMessage, { replyToId: null });
     });
 
     it('should handle send failures gracefully', async () => {
@@ -73,7 +81,7 @@ describe('chatSender.js', () => {
         await new Promise(resolve => setTimeout(resolve, 10));
 
         expect(mockChatClient.sendMessage).toHaveBeenCalledTimes(2);
-        expect(mockChatClient.sendMessage).toHaveBeenNthCalledWith(1, '#testchannel', 'Msg 1');
-        expect(mockChatClient.sendMessage).toHaveBeenNthCalledWith(2, '#testchannel', 'Msg 2');
+        expect(mockChatClient.sendMessage).toHaveBeenNthCalledWith(1, '#testchannel', 'Msg 1', { replyToId: null });
+        expect(mockChatClient.sendMessage).toHaveBeenNthCalledWith(2, '#testchannel', 'Msg 2', { replyToId: null });
     });
 });

--- a/tests/unit/commandProcessor.test.js
+++ b/tests/unit/commandProcessor.test.js
@@ -6,7 +6,7 @@ import { jest } from '@jest/globals';
 describe('commandProcessor module', () => {
   let commandProcessor;
   let mockLogger;
-  let mockIrcClient;
+  let mockChatSender;
 
   beforeEach(async () => {
     jest.resetModules();
@@ -19,18 +19,16 @@ describe('commandProcessor module', () => {
       error: jest.fn()
     };
 
-    // Mock IRC client
-    mockIrcClient = {
-      say: jest.fn().mockResolvedValue(undefined)
+    // Mock chat sender
+    mockChatSender = {
+      enqueueMessage: jest.fn().mockResolvedValue(undefined)
     };
 
     jest.unstable_mockModule('../../src/lib/logger.js', () => ({
       default: mockLogger
     }));
 
-    jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-      getIrcClient: jest.fn(() => mockIrcClient)
-    }));
+    jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
 
     // Mock command handlers - will be customized per test
     jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
@@ -248,9 +246,7 @@ describe('commandProcessor module', () => {
         default: mockLogger
       }));
 
-      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-        getIrcClient: jest.fn(() => mockIrcClient)
-      }));
+      jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
 
       jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
         default: {}
@@ -287,9 +283,7 @@ describe('commandProcessor module', () => {
         default: mockLogger
       }));
 
-      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-        getIrcClient: jest.fn(() => mockIrcClient)
-      }));
+      jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
 
       jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
         default: {
@@ -316,9 +310,7 @@ describe('commandProcessor module', () => {
         default: mockLogger
       }));
 
-      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-        getIrcClient: jest.fn(() => mockIrcClient)
-      }));
+      jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
 
       jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
         default: {
@@ -349,9 +341,7 @@ describe('commandProcessor module', () => {
         default: mockLogger
       }));
 
-      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-        getIrcClient: jest.fn(() => mockIrcClient)
-      }));
+      jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
 
       jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
         default: {
@@ -392,9 +382,7 @@ describe('commandProcessor module', () => {
         default: mockLogger
       }));
 
-      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-        getIrcClient: jest.fn(() => mockIrcClient)
-      }));
+      jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
 
       jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
         default: {
@@ -426,9 +414,7 @@ describe('commandProcessor module', () => {
         default: mockLogger
       }));
 
-      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-        getIrcClient: jest.fn(() => mockIrcClient)
-      }));
+      jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
 
       jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
         default: {
@@ -460,13 +446,7 @@ describe('commandProcessor module', () => {
         default: mockLogger
       }));
 
-      const mockIrc = {
-        say: jest.fn().mockResolvedValue(undefined)
-      };
-
-      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-        getIrcClient: jest.fn(() => mockIrc)
-      }));
+      jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
 
       jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
         default: {
@@ -483,7 +463,7 @@ describe('commandProcessor module', () => {
       );
 
       expect(mockLogger.error).toHaveBeenCalled();
-      expect(mockIrc.say).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#channel',
         'Oops! Something went wrong trying to run !error.'
       );
@@ -502,9 +482,7 @@ describe('commandProcessor module', () => {
         default: mockLogger
       }));
 
-      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-        getIrcClient: jest.fn(() => mockIrcClient)
-      }));
+      jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
 
       jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
         default: {
@@ -525,15 +503,14 @@ describe('commandProcessor module', () => {
           message: '!test arg1 arg2',
           command: 'test',
           replyToId: 'msg123',
-          ircClient: mockIrcClient,
           logger: mockLogger
         })
       );
     });
   });
 
-  describe('bot-free mode blocking', () => {
-    test('should block command execution when channel is in bot-free mode (anonymous)', async () => {
+  describe('bot responses in chat setting', () => {
+    test('should execute command when botRespondsInChat is false (commands still work)', async () => {
       const mockHandler = {
         execute: jest.fn().mockResolvedValue(undefined),
         permission: 'everyone'
@@ -545,58 +522,11 @@ describe('commandProcessor module', () => {
         default: mockLogger
       }));
 
-      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-        getIrcClient: jest.fn(() => mockIrcClient),
-        isAnonymousMode: jest.fn(() => false) // Global IRC is authenticated
-      }));
+      jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
 
       jest.unstable_mockModule('../../src/components/tts/ttsState.js', () => ({
         getTtsState: jest.fn(() => Promise.resolve({
-          botMode: 'anonymous' // Channel is in bot-free mode
-        }))
-      }));
-
-      jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
-        default: {
-          'tts': mockHandler
-        }
-      }));
-
-      commandProcessor = await import('../../src/components/commands/commandProcessor.js');
-
-      const result = await commandProcessor.processMessage(
-        'testchannel',
-        { username: 'user', id: 'msg123' },
-        '!tts test'
-      );
-
-      expect(mockHandler.execute).not.toHaveBeenCalled();
-      expect(result).toBeNull();
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        expect.stringContaining('Command !tts blocked: channel testchannel is in bot-free mode')
-      );
-    });
-
-    test('should allow command execution when channel is in authenticated mode', async () => {
-      const mockHandler = {
-        execute: jest.fn().mockResolvedValue(undefined),
-        permission: 'everyone'
-      };
-
-      jest.resetModules();
-
-      jest.unstable_mockModule('../../src/lib/logger.js', () => ({
-        default: mockLogger
-      }));
-
-      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-        getIrcClient: jest.fn(() => mockIrcClient),
-        isAnonymousMode: jest.fn(() => false) // Global IRC is authenticated
-      }));
-
-      jest.unstable_mockModule('../../src/components/tts/ttsState.js', () => ({
-        getTtsState: jest.fn(() => Promise.resolve({
-          botMode: 'authenticated' // Channel allows bot commands
+          botRespondsInChat: false // Bot doesn't respond in chat, but commands still execute
         }))
       }));
 
@@ -618,7 +548,7 @@ describe('commandProcessor module', () => {
       expect(result).toBe('tts');
     });
 
-    test('should default to anonymous mode if getTtsState fails', async () => {
+    test('should execute command when botRespondsInChat is true', async () => {
       const mockHandler = {
         execute: jest.fn().mockResolvedValue(undefined),
         permission: 'everyone'
@@ -630,10 +560,45 @@ describe('commandProcessor module', () => {
         default: mockLogger
       }));
 
-      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-        getIrcClient: jest.fn(() => mockIrcClient),
-        isAnonymousMode: jest.fn(() => false)
+      jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
+
+      jest.unstable_mockModule('../../src/components/tts/ttsState.js', () => ({
+        getTtsState: jest.fn(() => Promise.resolve({
+          botRespondsInChat: true // Bot responds in chat
+        }))
       }));
+
+      jest.unstable_mockModule('../../src/components/commands/handlers/index.js', () => ({
+        default: {
+          'tts': mockHandler
+        }
+      }));
+
+      commandProcessor = await import('../../src/components/commands/commandProcessor.js');
+
+      const result = await commandProcessor.processMessage(
+        'testchannel',
+        { username: 'user', id: 'msg123' },
+        '!tts test'
+      );
+
+      expect(mockHandler.execute).toHaveBeenCalled();
+      expect(result).toBe('tts');
+    });
+
+    test('should still execute command if getTtsState fails (defaults to no chat responses)', async () => {
+      const mockHandler = {
+        execute: jest.fn().mockResolvedValue(undefined),
+        permission: 'everyone'
+      };
+
+      jest.resetModules();
+
+      jest.unstable_mockModule('../../src/lib/logger.js', () => ({
+        default: mockLogger
+      }));
+
+      jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
 
       jest.unstable_mockModule('../../src/components/tts/ttsState.js', () => ({
         getTtsState: jest.fn(() => Promise.reject(new Error('Firestore error')))
@@ -653,19 +618,19 @@ describe('commandProcessor module', () => {
         '!tts test'
       );
 
-      // Should block because it defaults to anonymous mode on error
-      expect(mockHandler.execute).not.toHaveBeenCalled();
-      expect(result).toBeNull();
+      // Should still execute command, but defaults to canReply=false
+      expect(mockHandler.execute).toHaveBeenCalled();
+      expect(result).toBe('tts');
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({
           err: expect.any(Error),
           channel: 'testchannel'
         }),
-        expect.stringContaining('Error fetching channel botMode')
+        expect.stringContaining('Error fetching channel settings')
       );
     });
 
-    test('should block when global IRC is anonymous even if channel botMode is authenticated', async () => {
+    test('should pass canReply=false to context when botRespondsInChat is false', async () => {
       const mockHandler = {
         execute: jest.fn().mockResolvedValue(undefined),
         permission: 'everyone'
@@ -677,14 +642,11 @@ describe('commandProcessor module', () => {
         default: mockLogger
       }));
 
-      jest.unstable_mockModule('../../src/components/twitch/ircClient.js', () => ({
-        getIrcClient: jest.fn(() => mockIrcClient),
-        isAnonymousMode: jest.fn(() => true) // Global IRC is anonymous
-      }));
+      jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
 
       jest.unstable_mockModule('../../src/components/tts/ttsState.js', () => ({
         getTtsState: jest.fn(() => Promise.resolve({
-          botMode: 'authenticated' // This shouldn't matter when global is anonymous
+          botRespondsInChat: false
         }))
       }));
 
@@ -702,10 +664,13 @@ describe('commandProcessor module', () => {
         '!tts test'
       );
 
-      // Should still execute since we only block on channel-level anonymous mode
-      // The global anonymous mode is for when NO channels have auth
-      expect(mockHandler.execute).not.toHaveBeenCalled();
-      expect(result).toBeNull();
+      expect(mockHandler.execute).toHaveBeenCalled();
+      expect(mockHandler.execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          canReply: false
+        })
+      );
+      expect(result).toBe('tts');
     });
   });
 });

--- a/tests/unit/ttsCommands.test.js
+++ b/tests/unit/ttsCommands.test.js
@@ -5,7 +5,7 @@ import { jest } from '@jest/globals';
 
 describe('TTS Command Handlers', () => {
   let mockLogger;
-  let mockIrcSender;
+  let mockChatSender;
   let mockTtsQueue;
   let mockTtsState;
   let mockTtsService;
@@ -22,7 +22,7 @@ describe('TTS Command Handlers', () => {
       error: jest.fn()
     };
 
-    mockIrcSender = {
+    mockChatSender = {
       enqueueMessage: jest.fn()
     };
 
@@ -50,7 +50,7 @@ describe('TTS Command Handlers', () => {
       default: mockLogger
     }));
 
-    jest.unstable_mockModule('../../src/lib/ircSender.js', () => mockIrcSender);
+    jest.unstable_mockModule('../../src/lib/chatSender.js', () => mockChatSender);
     jest.unstable_mockModule('../../src/components/tts/ttsQueue.js', () => mockTtsQueue);
     jest.unstable_mockModule('../../src/components/tts/ttsState.js', () => mockTtsState);
     jest.unstable_mockModule('../../src/components/tts/ttsService.js', () => mockTtsService);
@@ -83,7 +83,7 @@ describe('TTS Command Handlers', () => {
       await stopCommand.default.execute(context);
 
       expect(mockTtsQueue.stopCurrentSpeech).toHaveBeenCalledWith('testchannel');
-      expect(mockIrcSender.enqueueMessage).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#testchannel',
         expect.stringContaining('STOPPED'),
         { replyToId: '123' }
@@ -110,7 +110,7 @@ describe('TTS Command Handlers', () => {
       await stopCommand.default.execute(context);
 
       expect(mockTtsQueue.stopCurrentSpeech).toHaveBeenCalled();
-      expect(mockIrcSender.enqueueMessage).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#testchannel',
         expect.stringContaining('STOPPED'),
         { replyToId: '123' }
@@ -136,7 +136,7 @@ describe('TTS Command Handlers', () => {
       await stopCommand.default.execute(context);
 
       expect(mockTtsQueue.stopCurrentSpeech).not.toHaveBeenCalled();
-      expect(mockIrcSender.enqueueMessage).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#testchannel',
         expect.stringContaining('only stop your own'),
         { replyToId: '123' }
@@ -184,7 +184,7 @@ describe('TTS Command Handlers', () => {
       await stopCommand.default.execute(context);
 
       expect(mockTtsQueue.stopCurrentSpeech).toHaveBeenCalled();
-      expect(mockIrcSender.enqueueMessage).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#testchannel',
         expect.stringContaining('stop signal'),
         { replyToId: '123' }
@@ -210,7 +210,7 @@ describe('TTS Command Handlers', () => {
       await stopCommand.default.execute(context);
 
       expect(mockTtsQueue.stopCurrentSpeech).not.toHaveBeenCalled();
-      expect(mockIrcSender.enqueueMessage).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#testchannel',
         expect.stringContaining('Nothing appears'),
         { replyToId: '123' }
@@ -237,7 +237,7 @@ describe('TTS Command Handlers', () => {
       await clearCommand.default.execute(context);
 
       expect(mockTtsQueue.clearQueue).toHaveBeenCalledWith('testchannel');
-      expect(mockIrcSender.enqueueMessage).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#testchannel',
         expect.stringContaining('CLEARED'),
         { replyToId: '123' }
@@ -295,7 +295,7 @@ describe('TTS Command Handlers', () => {
 
       await voiceCommand.default.execute(context);
 
-      expect(mockIrcSender.enqueueMessage).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#testchannel',
         expect.stringContaining('Friendly_Person'),
         { replyToId: '123' }
@@ -314,7 +314,7 @@ describe('TTS Command Handlers', () => {
 
       await voiceCommand.default.execute(context);
 
-      expect(mockIrcSender.enqueueMessage).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#testchannel',
         expect.stringContaining("haven't set"),
         { replyToId: '123' }
@@ -337,7 +337,7 @@ describe('TTS Command Handlers', () => {
         'testuser',
         'voiceId'
       );
-      expect(mockIrcSender.enqueueMessage).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#testchannel',
         expect.stringContaining('reset'),
         { replyToId: '123' }
@@ -402,7 +402,7 @@ describe('TTS Command Handlers', () => {
         'voiceId',
         'Friendly_Person'
       );
-      expect(mockIrcSender.enqueueMessage).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#testchannel',
         expect.stringContaining('Friendly_Person'),
         { replyToId: '123' }
@@ -470,7 +470,7 @@ describe('TTS Command Handlers', () => {
 
       await voiceCommand.default.execute(context);
 
-      expect(mockIrcSender.enqueueMessage).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#testchannel',
         expect.stringContaining('Could not set'),
         { replyToId: '123' }
@@ -489,7 +489,7 @@ describe('TTS Command Handlers', () => {
 
       await voiceCommand.default.execute(context);
 
-      expect(mockIrcSender.enqueueMessage).toHaveBeenCalledWith(
+      expect(mockChatSender.enqueueMessage).toHaveBeenCalledWith(
         '#testchannel',
         expect.stringContaining('Could not reset'),
         { replyToId: '123' }


### PR DESCRIPTION
Fixed all test failures after migrating from IRC to EventSub architecture:

- Updated ttsCommands.test.js to use chatSender instead of ircSender
- Updated commandProcessor.test.js to remove IRC client dependencies and update bot-free mode tests to use botRespondsInChat setting
- Updated chatSender.test.js to match new function signatures with replyToId parameter and mock ttsState for botRespondsInChat checks
- Updated chatClient.test.js to properly mock auth, config, and axios with correct response format for Helix API

All 191 tests now passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates unit tests to use `chatSender` and Helix Chat API (with auth headers), adjust function signatures with `replyToId`, and incorporate `botRespondsInChat` handling.
> 
> - **Tests**:
>   - **chatClient**:
>     - Mock `config`, `auth.getClientId`, and `axios` to validate Helix `POST https://api.twitch.tv/helix/chat/messages` with proper headers and response shape.
>     - Separate broadcaster/bot ID lookups and assert success/failure/error paths.
>   - **chatSender**:
>     - Update expectations to pass `{ replyToId: null }` and ensure message truncation/order handling.
>     - Mock `ttsState.getTtsState` for `botRespondsInChat`.
>   - **commandProcessor**:
>     - Remove IRC client dependencies; use `chatSender.enqueueMessage` for replies.
>     - Add tests for `botRespondsInChat` and `canReply` in context; keep permission/parse behaviors.
>   - **ttsCommands**:
>     - Replace `ircSender` with `chatSender`; verify replies include `{ replyToId }`.
>     - Validate TTS queue controls and voice preference flows (set/reset/fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b5cd5a66fc2eed2034df0f379ea8eca139302a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->