### PR TITLE
fix: Update permission command handler to accept VIP level

### DIFF
--- a/src/components/commands/tts/permission.js
+++ b/src/components/commands/tts/permission.js
@@ -5,8 +5,8 @@ import logger from '../../../lib/logger.js';
 
 export default {
     name: 'permission',
-    description: 'Sets whether TTS reads messages from everyone or only mods when in "all" mode.',
-    usage: '!tts permission <everyone|all|mods>',
+    description: 'Sets whether TTS reads messages from everyone, VIPs, or only mods when in "all" mode.',
+    usage: '!tts permission <everyone|all|vip|mods>',
     permission: 'moderator',
     execute: async (context) => {
         const { channel, user, args, replyToId } = context;
@@ -16,7 +16,7 @@ export default {
 
         if (args.length === 0) {
             const currentPermission = currentConfig.ttsPermissionLevel || 'everyone';
-            enqueueMessage(channel, `TTS message permission is currently set to: ${currentPermission}. Usage: !tts permission <everyone|all|mods>`, { replyToId });
+            enqueueMessage(channel, `TTS message permission is currently set to: ${currentPermission}. Usage: !tts permission <everyone|all|vip|mods>`, { replyToId });
             return;
         }
 
@@ -27,8 +27,8 @@ export default {
             newPermission = 'everyone';
         }
 
-        if (newPermission !== 'everyone' && newPermission !== 'mods') {
-            enqueueMessage(channel, `Invalid permission level. Use 'everyone' (or 'all') or 'mods'.`, { replyToId });
+        if (newPermission !== 'everyone' && newPermission !== 'vip' && newPermission !== 'mods') {
+            enqueueMessage(channel, `Invalid permission level. Use 'everyone' (or 'all'), 'vip', or 'mods'.`, { replyToId });
             return;
         }
 


### PR DESCRIPTION
The permission command handler now properly accepts 'vip' as a valid argument. Updated validation logic, usage strings, and error messages to include VIP alongside everyone/all and mods options.

This completes the VIP feature implementation by allowing moderators to set TTS permission level to VIP via the !tts permission vip command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds 'vip' as a valid TTS permission level and updates usage, validation, and messages accordingly.
> 
> - **TTS Command (`src/components/commands/tts/permission.js`)**:
>   - Add support for `vip` permission level alongside `everyone`/`all` and `mods`.
>   - Update `description`, `usage`, and validation/error messages to include `vip`.
>   - Help response reflects current setting and new options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9342ad56a593258ae0c537a45b87657bed8b2c50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->